### PR TITLE
 Add Personal Access Token support 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,3 +28,6 @@ jobs:
     - name: Check application with mypy
       run: |
         mypy .
+    - name: Run tests with pytest
+      run: |
+        pytest .

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You must set some environment variables to configure access to the Domino deploy
 * `DOMINO_AUTH_TOKEN` - An administrator's Personal Access Token (Domino 6.3.0+). Sent as `Authorization: Bearer`. Takes precedence over `DOMINO_API_KEY` when both are set.
 * `DOMINO_API_KEY` - An administrator's legacy Domino API key. Sent as `X-Domino-Api-Key`. If the value is a JWT (a PAT pasted here by mistake), it is sent as a Bearer token instead.
 * `DOMINO_HOSTNAME` - The URL to your Domino deployment, including protocol (and port if non-standard).
-* `DOMINO_SSL_NO_VERIFY` - **Optional** Set to "true" to disabled server certificate verification.
+* `DOMINO_SSL_NO_VERIFY` - **Optional** Set to "true" to disable server certificate verification.
 
 Note on PATs: a user's Personal Access Tokens are all invalidated when their roles change (immediately when changed by an admin; at next login when synced from the IdP). For long-running `shutdown`/`restore` operations, avoid role changes on the token's owner mid-operation, or use a legacy API key.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Easily place Domino in maintenance mode for upgrades and restore afterwards.
 
 `pip install git+https://github.com/dominodatalab/domino-maintenance-mode.git`
 
-Note: Currently requires python < 3.11
+Note: Requires Python 3.10+
 
 # Configuration
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ Note: Currently requires python < 3.11
 
 You must set some environment variables to configure access to the Domino deployment.
 
-* `DOMINO_API_KEY` - An administrator's Domino API key.
+* `DOMINO_AUTH_TOKEN` - An administrator's Personal Access Token (Domino 6.3.0+). Sent as `Authorization: Bearer`. Takes precedence over `DOMINO_API_KEY` when both are set.
+* `DOMINO_API_KEY` - An administrator's legacy Domino API key. Sent as `X-Domino-Api-Key`. If the value is a JWT (a PAT pasted here by mistake), it is sent as a Bearer token instead.
 * `DOMINO_HOSTNAME` - The URL to your Domino deployment, including protocol (and port if non-standard).
 * `DOMINO_SSL_NO_VERIFY` - **Optional** Set to "true" to disabled server certificate verification.
+
+Note on PATs: a user's Personal Access Tokens are all invalidated when their roles change (immediately when changed by an admin; at next login when synced from the IdP). For long-running `shutdown`/`restore` operations, avoid role changes on the token's owner mid-operation, or use a legacy API key.
 
 # Usage
 

--- a/domino_maintenance_mode/execution_interface.py
+++ b/domino_maintenance_mode/execution_interface.py
@@ -8,7 +8,7 @@ import requests
 
 from domino_maintenance_mode.projects import Project
 from domino_maintenance_mode.util import (
-    get_api_key,
+    get_auth_headers,
     get_hostname,
     should_verify,
 )
@@ -35,7 +35,7 @@ class ExecutionInterface(ABC, Generic[Id]):
 
     def __init__(self, **kwargs):
         self.hostname = get_hostname()
-        self.api_key = get_api_key()
+        self.auth_headers = get_auth_headers()
         pass
 
     def __get_session(self) -> requests.Session:
@@ -45,7 +45,7 @@ class ExecutionInterface(ABC, Generic[Id]):
             self.session.headers.update(
                 {
                     "Content-Type": "application/json",
-                    "X-Domino-Api-Key": self.api_key,
+                    **self.auth_headers,
                 }
             )
             self.session.verify = should_verify()
@@ -91,7 +91,7 @@ class ExecutionInterface(ABC, Generic[Id]):
                 url=url,
                 headers={
                     "Content-Type": "application/json",
-                    "X-Domino-Api-Key": self.api_key,
+                    **self.auth_headers,
                 },
                 verify_ssl=verify,
             ) as response:

--- a/domino_maintenance_mode/manager.py
+++ b/domino_maintenance_mode/manager.py
@@ -28,7 +28,7 @@ class Manager:
 
     def __init__(
         self,
-        service: str = None,
+        service: Optional[str] = None,
         batch_size: int = 5,
         batch_interval_s: int = 5,
         max_failures: int = 5,
@@ -148,7 +148,7 @@ class Manager:
                     )
                 except Exception as e:
                     if is_dataclass(execution._id):
-                        key = execution._id._id
+                        key = getattr(execution._id, "_id")
                     else:
                         key = execution._id
                     failures[key] = failures.get(key, 0) + 1

--- a/domino_maintenance_mode/projects.py
+++ b/domino_maintenance_mode/projects.py
@@ -5,7 +5,7 @@ from typing import List
 import aiohttp
 
 from domino_maintenance_mode.util import (
-    get_api_key,
+    get_auth_headers,
     get_hostname,
     should_verify,
 )
@@ -21,7 +21,7 @@ class Project:
 
 
 async def fetch_projects() -> List[Project]:
-    api_key = get_api_key()
+    auth_headers = get_auth_headers()
     hostname = get_hostname()
     verify = should_verify()
     async with aiohttp.ClientSession() as session:
@@ -31,7 +31,7 @@ async def fetch_projects() -> List[Project]:
             url,
             headers={
                 "Content-Type": "application/json",
-                "X-Domino-Api-Key": api_key,
+                **auth_headers,
             },
             verify_ssl=verify,
         ) as response:

--- a/domino_maintenance_mode/util.py
+++ b/domino_maintenance_mode/util.py
@@ -1,16 +1,47 @@
 import asyncio
 import os
+from typing import Dict
+
+AUTH_TOKEN_ENV = "DOMINO_AUTH_TOKEN"
+API_KEY_ENV = "DOMINO_API_KEY"
 
 
-def get_api_key() -> str:
-    if "DOMINO_API_KEY" not in os.environ:
-        raise Exception(
-            (
-                "Please specify Domino API key using "
-                "'DOMINO_API_KEY' environment variable."
-            )
+def _is_jwt(value: str) -> bool:
+    """Keycloak bearer tokens (e.g. Personal Access Tokens) are JWTs:
+    three dot-separated segments with an 'eyJ' header prefix. Legacy
+    Domino API keys are opaque strings and never match this shape."""
+    return value.startswith("eyJ") and len(value.split(".")) == 3
+
+
+def get_auth_headers() -> Dict[str, str]:
+    """Resolve the Domino credential and return its auth header.
+
+    Resolution order:
+    1. DOMINO_AUTH_TOKEN -> 'Authorization: Bearer <token>' (a Personal
+       Access Token, available since Domino 6.3.0, or any Keycloak
+       bearer token).
+    2. DOMINO_API_KEY -> 'X-Domino-Api-Key' (legacy admin API key).
+       A JWT-shaped value here is sent as a bearer token instead: a PAT
+       placed in DOMINO_API_KEY would otherwise be sent as a legacy key
+       and rejected by the API as an anonymous request.
+    """
+    token = os.environ.get(AUTH_TOKEN_ENV)
+    if token:
+        return {"Authorization": f"Bearer {token}"}
+
+    api_key = os.environ.get(API_KEY_ENV)
+    if api_key:
+        if _is_jwt(api_key):
+            return {"Authorization": f"Bearer {api_key}"}
+        return {"X-Domino-Api-Key": api_key}
+
+    raise Exception(
+        (
+            "No Domino credential found. Set 'DOMINO_AUTH_TOKEN' to a "
+            "Personal Access Token (Domino 6.3.0+), or "
+            "'DOMINO_API_KEY' to an administrator's legacy API key."
         )
-    return os.environ["DOMINO_API_KEY"]
+    )
 
 
 def get_hostname() -> str:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 black==22.3.0
 flake8==3.8.4
-mypy==0.800
+mypy==2.3.0
 pytest==6.2.2
 isort==5.10.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 black==22.3.0
 flake8==3.8.4
 mypy==2.3.0
-pytest==6.2.2
+pytest==8.3.4
 isort==5.10.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 black==22.3.0
 flake8==3.8.4
 mypy==2.3.0
-pytest==8.3.4
+pytest==9.0.3
 isort==5.10.1

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,42 @@
+import pytest
+
+from domino_maintenance_mode.util import get_auth_headers
+
+LEGACY_KEY = "abc123opaquekey"
+# Header-only JWT shape (three dot-separated segments, "eyJ" prefix).
+# Not a real token.
+PAT_JWT = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig"
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    monkeypatch.delenv("DOMINO_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("DOMINO_API_KEY", raising=False)
+
+
+def test_auth_token_env_takes_precedence(monkeypatch):
+    monkeypatch.setenv("DOMINO_AUTH_TOKEN", PAT_JWT)
+    monkeypatch.setenv("DOMINO_API_KEY", LEGACY_KEY)
+
+    assert get_auth_headers() == {"Authorization": f"Bearer {PAT_JWT}"}
+
+
+def test_legacy_api_key_still_works(monkeypatch):
+    monkeypatch.setenv("DOMINO_API_KEY", LEGACY_KEY)
+
+    assert get_auth_headers() == {"X-Domino-Api-Key": LEGACY_KEY}
+
+
+def test_jwt_shaped_api_key_is_sent_as_bearer(monkeypatch):
+    monkeypatch.setenv("DOMINO_API_KEY", PAT_JWT)
+
+    assert get_auth_headers() == {"Authorization": f"Bearer {PAT_JWT}"}
+
+
+def test_no_credentials_raises_with_both_var_names(monkeypatch):
+    with pytest.raises(Exception) as exc_info:
+        get_auth_headers()
+
+    message = str(exc_info.value)
+    assert "DOMINO_AUTH_TOKEN" in message
+    assert "DOMINO_API_KEY" in message


### PR DESCRIPTION
## What changed?

dmm authenticated only via the legacy `X-Domino-Api-Key` header, so a Personal Access Token (Domino 6.3.0+) was treated as no credential and every run failed with a misleading `403 "Anonymous user cannot list projects"`. Deployments that disable legacy API keys had no working way to run dmm at all.

- New credential resolution in `util.py` (`get_auth_headers()`):
  - `DOMINO_AUTH_TOKEN` → sent as `Authorization: Bearer` (PAT)
  - `DOMINO_API_KEY` → legacy `X-Domino-Api-Key`; a JWT-shaped value here is auto-detected and sent as Bearer, so a PAT pasted into the old variable now works instead of failing as anonymous
  - Neither set → immediate error naming both variables and the accepted credential types
- All three request-header sites (sync `requests.Session` + async aiohttp) use the resolved header
- README documents both variables, plus the PAT caveat that role changes invalidate a user's tokens (relevant to long shutdown/restore runs)
- Unit tests for the four resolution branches; pytest added to CI
- CI fix: bumped the mypy pin (0.800 crashed on modern click) and resolved the two pre-existing typing errors it surfaced in `manager.py`

## How was this tested?

- pytest unit tests cover all four credential-resolution branches

## Notes for reviewers

Start with `domino_maintenance_mode/util.py`