### PR TITLE
Skip "Never Started" apps in snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ dmm snapshot my-snapshot-file.json
 
 This will create a timestamped snapshot file which you will need to use in subsequent steps.
 
+On large deployments, if the snapshot fails with `504 Gateway Time-out`, lower
+the request concurrency (default `10`):
+
+```
+dmm snapshot --concurrency 3 my-snapshot-file.json
+```
+
 * Stop all running Apps, Model APIs, Restartable Workspaces, and Scheduled Jobs:
 
 ```

--- a/domino_maintenance_mode/interfaces/apps.py
+++ b/domino_maintenance_mode/interfaces/apps.py
@@ -15,7 +15,11 @@ from domino_maintenance_mode.projects import Project
 logger = logging.getLogger(__name__)
 
 # From https://github.com/cerebrotech/domino/blob/develop/common-core/src/main/scala/domino/common/models/RunStatus.scala  # noqa: E501
-STOPPED_STATES = {"Stopped", "Succeeded", "Failed", "Error"}
+# "Never Started" is an app-level status (a created-but-never-launched App)
+# not present in RunStatus; it is not a running state, so it must be skipped.
+# Without it these Apps leak past the filter and (when their publisher is a
+# deactivated user) error out on parse instead of being cleanly excluded.
+STOPPED_STATES = {"Stopped", "Succeeded", "Failed", "Error", "Never Started"}
 RUNNING_STATES = {"Running", "Serving"}
 
 

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -1,0 +1,64 @@
+import asyncio
+from unittest import mock
+
+import pytest
+
+from domino_maintenance_mode.interfaces.apps import Interface
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    # Interface.__init__ resolves hostname/credentials from the environment.
+    monkeypatch.setenv("DOMINO_HOSTNAME", "https://example.invalid")
+    monkeypatch.setenv("DOMINO_API_KEY", "test-key")
+
+
+def _app(id_, status, publisher={"userName": "alice"}):
+    return {
+        "id": id_,
+        "hardwareTierId": "small-k8s",
+        "projectId": "p1",
+        "name": f"app-{id_}",
+        "status": status,
+        "publisher": publisher,
+    }
+
+
+def _run(apps):
+    iface = Interface()
+    with mock.patch.object(iface, "get", return_value=apps):
+        return asyncio.run(iface.list_running(None, []))
+
+
+def test_running_app_is_captured():
+    result = _run([_app("1", "Running")])
+    assert [e._id._id for e in result] == ["1"]
+
+
+def test_never_started_app_is_skipped():
+    # Regression: "Never Started" is not a running state and must be excluded,
+    # regardless of publisher — previously it leaked past the status filter.
+    result = _run([_app("1", "Never Started")])
+    assert result == []
+
+
+def test_never_started_with_null_publisher_is_skipped_not_errored():
+    # A created-but-never-launched App whose publisher was a deactivated user
+    # (null). Must be skipped cleanly, not error-dropped and not wrongly
+    # captured.
+    result = _run([_app("1", "Never Started", publisher=None)])
+    assert result == []
+
+
+def test_stopped_states_are_skipped():
+    apps = [_app(s, s) for s in ("Stopped", "Succeeded", "Failed", "Error")]
+    assert _run(apps) == []
+
+
+def test_mixed_batch_keeps_only_running():
+    apps = [
+        _app("run", "Running"),
+        _app("never", "Never Started", publisher=None),
+        _app("stopped", "Stopped"),
+    ]
+    assert [e._id._id for e in _run(apps)] == ["run"]


### PR DESCRIPTION
## What changed?

`dmm snapshot` treated any App not in an explicitly "stopped" state as running. "Never Started" (a created-but-never-launched App) was not in that set, so those Apps leaked past the filter — and when their publisher was a deactivated user, errored out during parse instead of being cleanly excluded.

- Add `"Never Started"` to `STOPPED_STATES` so never-launched Apps are skipped, never captured in a snapshot (and so never targeted by a subsequent `shutdown`/`restore`)
- Add regression tests for the App status filter (running captured; never-started skipped with both valid and null publisher; stopped states skipped)
- README: note `--concurrency` as the remedy for `504 Gateway Time-out` on large deployments

## How was this tested?

- Added `tests/test_apps.py` covering the status-filter cases above; full suite passes
- Verified against a large deployment: only genuinely running Apps are captured; never-started Apps are excluded without error

## Notes for reviewers

Single-line change in `apps.py`; the tests document the intended filter behavior.